### PR TITLE
Replace a.m-category-cta background image with pure CSS circles

### DIFF
--- a/style.css
+++ b/style.css
@@ -51,16 +51,41 @@ button {
 	text-transform: uppercase;
 }
 a.m-category-cta {
-	display: block;
-	text-align: center;
-	background: url('images/circle.png') no-repeat;
-	background-size: 100% 100%;
-	width: 150px;
-	height: 150px;
-	padding: 55px 0;
-	text-decoration: none;
 	box-sizing: border-box;
 	color: #A0915C;
+	display: block;
+	height: 150px;
+	padding: 55px 0;
+	position: relative;
+	text-align: center;
+	text-decoration: none;
+	width: 150px;
+}
+a.m-category-cta:before,
+a.m-category-cta:after {
+	border-color: #A0915C;
+	border-radius: 50%;
+	border-style: solid;
+	border-width: 1px;
+	content: " ";
+	height: 95%;
+	position: absolute;
+	width: 95%;
+	z-index: 10;
+}
+a.m-category-cta:before {
+	bottom: 0;
+	opacity: .5;
+	right: 0;
+}
+a.m-category-cta:after {
+	left: 0;
+	top: 0;
+}
+a.m-category-cta span,
+a.m-category-cta h3 {
+	position: relative;
+	z-index: 20;
 }
 a.m-category-cta span {
 	font-family: 'Merriweather', serif;


### PR DESCRIPTION
PURE CSS OVER BG IMAGE: Replaced a.m-category-cta background image with pure css circles.

MINOR: Alphabeticise a.m-category-cta CSS declarations
